### PR TITLE
Add visitor benchmarks

### DIFF
--- a/c/bench/bench.c
+++ b/c/bench/bench.c
@@ -70,7 +70,7 @@ owf_time_t owf_bench_time_now() {
 
 bool owf_bench_lock_affinity(uint64_t cpu) {
     thread_t t = pthread_mach_thread_np(pthread_self());
-    thread_affinity_policy p = {0};
+    struct thread_affinity_policy p = {0};
     p.affinity_tag = 1 << cpu;
     return thread_policy_set(t, THREAD_AFFINITY_POLICY, (thread_policy_t)&p, THREAD_AFFINITY_POLICY_COUNT) == KERN_SUCCESS;
 }

--- a/c/msvc/libowf-bench.vcxproj
+++ b/c/msvc/libowf-bench.vcxproj
@@ -126,13 +126,15 @@
       <WarningLevel>Level3</WarningLevel>
       <PrecompiledHeader>
       </PrecompiledHeader>
-      <Optimization>MaxSpeed</Optimization>
+      <Optimization>Full</Optimization>
       <FunctionLevelLinking>true</FunctionLevelLinking>
       <IntrinsicFunctions>true</IntrinsicFunctions>
       <PreprocessorDefinitions>WIN32;NDEBUG;_CONSOLE;_LIB;%(PreprocessorDefinitions)</PreprocessorDefinitions>
       <AdditionalIncludeDirectories>$(SolutionDir)\..\include</AdditionalIncludeDirectories>
-      <FavorSizeOrSpeed>Speed</FavorSizeOrSpeed>
+      <FavorSizeOrSpeed>Size</FavorSizeOrSpeed>
       <MultiProcessorCompilation>true</MultiProcessorCompilation>
+      <OmitFramePointers>true</OmitFramePointers>
+      <WholeProgramOptimization>true</WholeProgramOptimization>
     </ClCompile>
     <Link>
       <SubSystem>Console</SubSystem>
@@ -149,13 +151,15 @@
       <WarningLevel>Level3</WarningLevel>
       <PrecompiledHeader>
       </PrecompiledHeader>
-      <Optimization>MaxSpeed</Optimization>
+      <Optimization>Full</Optimization>
       <FunctionLevelLinking>true</FunctionLevelLinking>
       <IntrinsicFunctions>true</IntrinsicFunctions>
       <PreprocessorDefinitions>WIN32;NDEBUG;_CONSOLE;_LIB;%(PreprocessorDefinitions)</PreprocessorDefinitions>
       <AdditionalIncludeDirectories>$(SolutionDir)\..\include</AdditionalIncludeDirectories>
-      <FavorSizeOrSpeed>Speed</FavorSizeOrSpeed>
+      <FavorSizeOrSpeed>Size</FavorSizeOrSpeed>
       <MultiProcessorCompilation>true</MultiProcessorCompilation>
+      <OmitFramePointers>true</OmitFramePointers>
+      <WholeProgramOptimization>true</WholeProgramOptimization>
     </ClCompile>
     <Link>
       <SubSystem>Console</SubSystem>

--- a/c/msvc/libowf.vcxproj
+++ b/c/msvc/libowf.vcxproj
@@ -103,7 +103,7 @@
       <SubSystem>Windows</SubSystem>
     </Link>
     <Lib>
-      <LinkTimeCodeGeneration>true</LinkTimeCodeGeneration>
+      <LinkTimeCodeGeneration>false</LinkTimeCodeGeneration>
     </Lib>
   </ItemDefinitionGroup>
   <ItemDefinitionGroup Condition="'$(Configuration)|$(Platform)'=='Debug|x64'">
@@ -122,7 +122,7 @@
       <SubSystem>Windows</SubSystem>
     </Link>
     <Lib>
-      <LinkTimeCodeGeneration>true</LinkTimeCodeGeneration>
+      <LinkTimeCodeGeneration>false</LinkTimeCodeGeneration>
     </Lib>
   </ItemDefinitionGroup>
   <ItemDefinitionGroup Condition="'$(Configuration)|$(Platform)'=='Release|Win32'">
@@ -136,8 +136,8 @@
       <WholeProgramOptimization>true</WholeProgramOptimization>
       <EnablePREfast>true</EnablePREfast>
       <MultiProcessorCompilation>true</MultiProcessorCompilation>
-      <FavorSizeOrSpeed>Speed</FavorSizeOrSpeed>
-      <Optimization>MaxSpeed</Optimization>
+      <FavorSizeOrSpeed>Size</FavorSizeOrSpeed>
+      <Optimization>Full</Optimization>
       <OmitFramePointers>true</OmitFramePointers>
     </ClCompile>
     <Link>
@@ -162,8 +162,8 @@
       <WholeProgramOptimization>true</WholeProgramOptimization>
       <EnablePREfast>true</EnablePREfast>
       <MultiProcessorCompilation>true</MultiProcessorCompilation>
-      <FavorSizeOrSpeed>Speed</FavorSizeOrSpeed>
-      <Optimization>MaxSpeed</Optimization>
+      <FavorSizeOrSpeed>Size</FavorSizeOrSpeed>
+      <Optimization>Full</Optimization>
       <OmitFramePointers>true</OmitFramePointers>
     </ClCompile>
     <Link>

--- a/c/src/owf/types.c
+++ b/c/src/owf/types.c
@@ -42,8 +42,9 @@ int owf_array_binary_compare(owf_array_t *lhs, owf_array_t *rhs, uint32_t width)
 bool owf_array_reserve(owf_array_t *arr, owf_alloc_t *alloc, owf_error_t *error, uint32_t capacity, uint32_t width) {
     /* Extend the capacity by a factor of 3/2.
      * Do a safe multiply by 3, then divide by 2.
+     * Keep 3 elements in this array, at minimum.
      */
-    capacity = OWF_MAX(capacity, 2);
+    capacity = OWF_MAX(capacity, 3);
     OWF_ARITH_SAFE_MUL32(error, capacity, 3);
     capacity /= 2;
 


### PR DESCRIPTION
7af5abf

Add benchmarks for OWF visitors, and bump the minimum array allocation size to 3 elements to improve performance.